### PR TITLE
Update huggingface link for MedGemma

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ consult our Intended Use Statement for more details.
     the model.
 
 *   Visit the model on
-    [Hugging Face](https://huggingface.co/models?other=medgemma) or
+    [Hugging Face](https://huggingface.co/collections/google/medgemma-release-680aade845f90bec6a3f60c4) or
     [Model Garden](https://console.cloud.google.com/vertex-ai/publishers/google/model-garden/medgemma).
 
 ## Contributing


### PR DESCRIPTION
Should not the link point to https://huggingface.co/collections/google/medgemma-release-680aade845f90bec6a3f60c4 ? 

Current link:
![image](https://github.com/user-attachments/assets/ff05e0fe-716e-4c06-9468-fe7657a15303)

Updated link:
![image](https://github.com/user-attachments/assets/9adbb83d-17cb-4756-8b5c-77f116d9274c)
